### PR TITLE
chore: actualizar las actions del workflow de despliegue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -43,7 +43,7 @@ jobs:
         run: python main.py
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs
 
@@ -56,4 +56,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Las cuatro actions emitían el aviso de deprecación de Node 20 y estaban siendo forzadas a correr sobre Node 24 por el runner.

  actions/checkout              v4 -> v7
  actions/setup-python          v5 -> v7
  actions/upload-pages-artifact v3 -> v5
  actions/deploy-pages          v4 -> v5